### PR TITLE
Fix for library path agnostic clients

### DIFF
--- a/include/mpark/in_place.hpp
+++ b/include/mpark/in_place.hpp
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-#include <mpark/variants/config.hpp>
+#include "variants/config.hpp"
 
 namespace mpark {
 

--- a/include/mpark/variant.hpp
+++ b/include/mpark/variant.hpp
@@ -203,9 +203,9 @@ namespace std {
 #include <type_traits>
 #include <utility>
 
-#include <mpark/in_place.hpp>
-#include <mpark/variants/config.hpp>
-#include <mpark/variants/lib.hpp>
+#include "in_place.hpp"
+#include "variants/config.hpp"
+#include "variants/lib.hpp"
 
 namespace mpark {
 

--- a/include/mpark/variants/lib.hpp
+++ b/include/mpark/variants/lib.hpp
@@ -14,7 +14,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <mpark/variants/config.hpp>
+#include "config.hpp"
 
 #define RETURN(...)                                          \
   noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { \


### PR DESCRIPTION
Currently internal header files are included by library paths, which assumes that library's include dir is known to compiler. This makes it impossible to compile the library under path agnostic scenario. For example, if another header-only library wants to use variant library it can't include it, unless the end user specifies variant's path separately in their make system. This PR converts includes of local files from global library style to local relative path style.