### PR TITLE
Disable MPARK_CPP14_CONSTEXPR for MSVC <= 19.15

### DIFF
--- a/include/mpark/config.hpp
+++ b/include/mpark/config.hpp
@@ -38,7 +38,8 @@
 #define MPARK_TYPE_PACK_ELEMENT
 #endif
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304 && \
+    !(defined(_MSC_VER) && _MSC_VER <= 1915)
 #define MPARK_CPP14_CONSTEXPR
 #endif
 


### PR DESCRIPTION
The latest Visual Studio 2017 update (version 15.8, MSVC 19.15)
claims to support C++14 constexpr, but it does not. Compiling with
MPARK_CPP14_CONSTEXPR defined emits a litany of errors, e.g.,

    5>c:\...\variant\include\mpark\variant.hpp(386): error C2131: expression did not evaluate to a constant
    5>c:\...\variant\include\mpark\variant.hpp(386): note: failure was caused by a read of a variable outside its lifetime
    5>c:\...\variant\include\mpark\variant.hpp(386): note: see usage of '<traits_0>'
    5>c:\...\variant\include\mpark\variant.hpp(1205): note: see reference to class template instantiation 'mpark::detail::traits<Redacted, Lol>' being compiled
    5>c:\...\variant\include\mpark\variant.hpp(1504): note: see reference to class template instantiation 'mpark::detail::impl<Redacted, Lol>' being compiled

Disable MPARK_CPP14_CONSTEXPR for this and previous versions of MSVC,
with the hope that this problem is addressed in the near future.

Fixes #48