### PR TITLE
Use constexpr compiler bug workaround for VS2017 version 15.9

### DIFF
--- a/include/mpark/config.hpp
+++ b/include/mpark/config.hpp
@@ -55,7 +55,7 @@
 #endif
 
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304 && \
-    !(defined(_MSC_VER) && _MSC_VER <= 1915)
+    !(defined(_MSC_VER) && _MSC_VER <= 1916)
 #define MPARK_CPP14_CONSTEXPR
 #endif
 


### PR DESCRIPTION
The latest version of Visual Studio 2017 (15.9) is still affected by the constexpr compiler bug, and they've incremented MSC_VER by 1.