### PR TITLE
Rename F type definition

### DIFF
--- a/include/mpark/variant.hpp
+++ b/include/mpark/variant.hpp
@@ -1512,8 +1512,8 @@ namespace mpark {
 
     template <std::size_t I, typename T>
     struct overload_leaf {
-      using F = lib::size_constant<I> (*)(T);
-      operator F() const { return nullptr; }
+      using impl = lib::size_constant<I> (*)(T);
+      operator impl() const { return nullptr; }
     };
 
     template <typename... Ts>


### PR DESCRIPTION
Hey,

first of all thanks for making this handy backport available 👍 
I'm using the library on Arduino and unfortunately it won't compile due to a collision.
This fix is pretty straight forward, if you want me to use a different name, I'm happy to fix it up.

------
Rename the overload_leaf operator type to something
more specific, as F() causes collisions with the Arduino library,
that defines this in their String library.