### PR TITLE
PGI 19.5: no decltype(auto)

### DIFF
--- a/include/mpark/config.hpp
+++ b/include/mpark/config.hpp
@@ -76,7 +76,7 @@
 #define MPARK_INTEGER_SEQUENCE
 #endif
 
-#if defined(__cpp_return_type_deduction) || defined(_MSC_VER)
+#if (defined(__cpp_decltype_auto) && defined(__cpp_return_type_deduction)) || defined(_MSC_VER)
 #define MPARK_RETURN_TYPE_DEDUCTION
 #endif
 


### PR DESCRIPTION
The PGI pgc++ compiler with `--c++11` in version 19.5 does not support `decltype(auto)` constructs from C++14. The proper test for this feature, as it is used for type deductions herein, is `__cpp_decltype_auto`.

Refs.:
  https://en.cppreference.com/w/cpp/feature_test
  https://gcc.gnu.org/projects/cxx-status.html