### PR TITLE
NVCC: Fix Compile with C++14 Constexpr

### DIFF
--- a/include/mpark/variant.hpp
+++ b/include/mpark/variant.hpp
@@ -1998,7 +1998,7 @@ namespace mpark {
     return false;
   }
 
-#ifdef MPARK_CPP14_CONSTEXPR
+#if defined(MPARK_CPP14_CONSTEXPR) && !defined(__NVCC__)
   namespace detail {
 
     inline constexpr bool all(std::initializer_list<bool> bs) {


### PR DESCRIPTION
Out of the many C++14 `constexpr` constructs, one does not compile with NVCC - even when using `-std=c++14 --expt-relaxed-constexpr`.

Seen with all versions of NVCC so far (latest tests with 10.1 and 10.2), occurs even if simply included for host-side code.

Fix #70

~~Update: uh, it helps to replace the brackets with an explicit constructor of an initializer list :)~~ *does not work*