### PR TITLE
now compiles in nvcc 10.2

### DIFF
--- a/include/mpark/variant.hpp
+++ b/include/mpark/variant.hpp
@@ -2001,20 +2001,20 @@ namespace mpark {
 #ifdef MPARK_CPP14_CONSTEXPR
   namespace detail {
 
-    inline constexpr bool all(std::initializer_list<bool> bs) {
+    inline constexpr bool any(std::initializer_list<bool> bs) {
       for (bool b : bs) {
-        if (!b) {
-          return false;
+        if (b) {
+          return true;
         }
       }
-      return true;
+      return false;
     }
 
   }  // namespace detail
 
   template <typename Visitor, typename... Vs>
   inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
-    return (detail::all({!vs.valueless_by_exception()...})
+    return (!detail::any({vs.valueless_by_exception()...})
                 ? (void)0
                 : throw_bad_variant_access()),
            detail::visitation::variant::visit_value(


### PR DESCRIPTION
So, using some xtensor stuff which uses variant.hpp, I was trying to unable to compile stuff with NVCC 10.2 (latest version), and encountered some parsing error in nvcc that is described in [this issue](https://github.com/xtensor-stack/xtl/issues/183) and this [PR](https://github.com/xtensor-stack/xtl/pull/184). It seems that part of the issue lies in xtensor-stack's xtl library and also this variant.hpp header file.

This PR just slightly changes an expression in variant.hpp so that the nvcc parser doesn't screw up. I think the code written here is valid beforehand, it's just that nvcc chokes on the parameter pack expansion somewhere.

The error which is encountered before this change, when including variant.hpp is:

```c++
gavin@gpad:~/scratch/variant/include/mpark$ nvcc nothing.cu 
variant.hpp: In function ‘constexpr decltype(auto) mpark::visit(Visitor&&, Vs&& ...)’:
variant.hpp:1967:96: error: parameter packs not expanded with ‘...’:
     return (detail::all({!vs.valueless_by_exception()...})
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                     ^                                                                                                      
variant.hpp:1967:96: note:         ‘vs’
```

No clue why this happens, but the changes here fix it.