### PR TITLE
GCC<=4.9: Exceptions

### DIFF
--- a/include/mpark/config.hpp
+++ b/include/mpark/config.hpp
@@ -64,7 +64,8 @@
 #endif
 
 #if __has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
-    (defined(_MSC_VER) && defined(_CPPUNWIND))
+    (defined(_MSC_VER) && defined(_CPPUNWIND)) || \
+    defined(__EXCEPTIONS)
 #define MPARK_EXCEPTIONS
 #endif
 


### PR DESCRIPTION
GCC 4.8 and 4.9 support exceptions, but are not detected as such.
This adds exception support for those compilers.

Detection taken from `nlohmann/json`:
* https://github.com/nlohmann/json/issues/498
* https://github.com/nlohmann/json/blob/v3.9.1/benchmarks/thirdparty/benchmark/src/internal_macros.h#L70-L73
* https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
```
__EXCEPTIONS

    This macro is defined, with value 1, when compiling a C++ source file with exceptions enabled. If -fno-exceptions is used when compiling the file, then this macro is not defined.
```