### PR TITLE
Apply patch for icpc

### DIFF
--- a/include/mpark/config.hpp
+++ b/include/mpark/config.hpp
@@ -50,7 +50,7 @@
 #define MPARK_BUILTIN_UNREACHABLE
 #endif
 
-#if __has_builtin(__type_pack_element)
+#if __has_builtin(__type_pack_element) && !(defined(__ICC))
 #define MPARK_TYPE_PACK_ELEMENT
 #endif
 


### PR DESCRIPTION
icpc in some way utilizes the preprocessor of the associated "developer
tools" used by the compiler. This leads to, in some cases, a
preprocessor claiming support for `__tuple_element_packs`, even though
icpc (as of version 21.1) can't actually parse such code.  Just use the
MPARK_TUPLE_ELEMENT_PACK impl with __icc until icpc supports it.

Fixes #77

FYI, even with this patch, icpc 19.1.3  fails to compile one of the mpark tests (I couldn't seem to clone the llvm tests on my system, but probably because of our network).  All tests but this one compiled and passed:

```
/Users/sbolding/codes/mcnp6/build/git-submodule-packages/mpark-variant/test/assign.fwd.cpp(53): error: static assertion failed with "variant<short, long> v; v = 42;"
    static_assert(std::is_assignable<mpark::variant<short, long>, int>{},
```

I imagine any Intel users are already working around this if they needed to SFINAE on something like this, so I am OK with this limitation until the new Intel clang front ends are widely available :), but without this patch we can't build at all on Catalina.
