### PR TITLE
Added PlatformIO manifest library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,26 @@
+{
+  "name": "MPark-Variant",
+  "version": "1.4.0",
+  "keywords": "C++ std variant",
+  "description": "MPark.Variant is an implementation of C++17 std::variant for C++11/14/17.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mpark/variant"
+  },
+  "authors": [{
+    "name": "Michael Park",
+    "email": "mcypark@gmail.com"
+  }],
+  "frameworks": "*",
+  "platforms": "*",
+  "export": {
+    "include": [
+      "include/mpark/*"
+    ]
+  },
+  "build": {
+    "srcFilter": [
+      "-<*>"
+    ]
+  }
+}


### PR DESCRIPTION
I have added [PlatformIO](http://platformio.org/) manifest [library.json](https://docs.platformio.org/en/latest/manifests/library-json/index.html).

Currently I published it in registry under my account (hacker-cb): https://registry.platformio.org/libraries/hacker-cb/MPark-Variant but you can make your own account to publish official releases.